### PR TITLE
Enhance sorting functionality in AgentTable

### DIFF
--- a/src/components/AgentTable.js
+++ b/src/components/AgentTable.js
@@ -11,10 +11,25 @@ const AgentTable = ({ tableData, meta, kpis }) => {
     let sortableItems = [...tableData];
     if (sortConfig !== null) {
       sortableItems.sort((a, b) => {
-        if (a[sortConfig.key] < b[sortConfig.key]) {
+        let aVal = a[sortConfig.key];
+        let bVal = b[sortConfig.key];
+        
+        // Use raw seconds values for time-based sorting
+        if (sortConfig.key === "logged_in") {
+          aVal = a.logged_in_seconds;
+          bVal = b.logged_in_seconds;
+        } else if (sortConfig.key === "mean_ring") {
+          aVal = a.mean_ring_seconds;
+          bVal = b.mean_ring_seconds;
+        } else if (sortConfig.key === "mean_talk") {
+          aVal = a.mean_talk_seconds;
+          bVal = b.mean_talk_seconds;
+        }
+        
+        if (aVal < bVal) {
           return sortConfig.direction === "ascending" ? -1 : 1;
         }
-        if (a[sortConfig.key] > b[sortConfig.key]) {
+        if (aVal > bVal) {
           return sortConfig.direction === "ascending" ? 1 : -1;
         }
         return 0;

--- a/src/services/reportService.js
+++ b/src/services/reportService.js
@@ -101,9 +101,12 @@ export function build(range, selectedQueues = null) {
         agent: x.Agent,
         calls: x.Calls,
         logged_in: secondsToHMS(x.Logged),
+        logged_in_seconds: x.Logged, // Raw seconds for sorting
         ans_per_hour: ansPerHour,
         mean_ring: secondsToHMS(meanRing),
+        mean_ring_seconds: meanRing, // Raw seconds for sorting
         mean_talk: secondsToHMS(meanTalk),
+        mean_talk_seconds: meanTalk, // Raw seconds for sorting
       };
     })
     .sort((a, b) => b.calls - a.calls);


### PR DESCRIPTION
Improve sorting in the AgentTable by using raw seconds for time-based fields, allowing for more accurate and efficient sorting of logged-in time, mean ring time, and mean talk time.